### PR TITLE
Form correction

### DIFF
--- a/public/ResourceView.js
+++ b/public/ResourceView.js
@@ -143,6 +143,8 @@ class ResourceView extends View{
 	toggleEdit(){
 		$('#edit-resource-form-' + this.id).toggleClass('d-none');
 		$('#' + this.id).toggleClass('d-none');
+		$('#edit-resource-title-' + this.id ).val(this.title);
+		$('#edit-resource-description-' + this.id ).val(this.description);
 		$('#edit-resource-title-' + this.id).focus();
 	}
 


### PR DESCRIPTION
Now, when the form is closed and re-opened, if the user did not press 'save', the state of the form comes back to the real data of the resource at that time. Fixes #20 