### PR TITLE
Edit resource form fix

### DIFF
--- a/public/ResourceController.js
+++ b/public/ResourceController.js
@@ -7,6 +7,21 @@ class ResourceController extends Controller {
 
 	updateResource(newTitle, newDescription){
 		return new Promise(resolve => {
+			let validations = {
+				title: this.validateField(newTitle, '', 'Invalid Title', 'The Title field must not be empty.'),
+				description: this.validateField(newDescription, '', 'Invalid Description', 'The Description field must not be empty.'),
+			}
+
+			for (const key in validations) {
+				if (validations.hasOwnProperty(key)) {
+					const element = validations[key];
+					if (element instanceof Error){
+						resolve(element);
+						return;
+					}
+				}
+			}
+			
 			this.dbRef.update({
 				title: newTitle,
 				description: newDescription,

--- a/public/ResourceView.js
+++ b/public/ResourceView.js
@@ -155,6 +155,7 @@ class ResourceView extends View{
 		$('#edit-resource-title-' + this.id ).val(this.title);
 		$('#edit-resource-description-' + this.id ).val(this.description);
 		$('#edit-resource-title-' + this.id).focus();
+		$('#edit-resource-' + this.id + 'alert').remove();
 	}
 
 	async update(){
@@ -164,7 +165,7 @@ class ResourceView extends View{
 		const response = await this.controller.updateResource(title, description);
 		
 		if (response instanceof Error){
-			createErrorAlert(response, 'edit-resource-' + this.id + 'alert', 'edit-resource-form-' + this.id);
+			this.createErrorAlert(response, 'edit-resource-' + this.id + 'alert', 'edit-resource-form-' + this.id);
 			return;
 		}
 


### PR DESCRIPTION
Now the edit form works as expected. It doesn't allow invalid values and deletes the error alert when the form is closed and re-opened again. Fixes #55 